### PR TITLE
Add raise custom timeout exception to status.wait

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -439,9 +439,7 @@ class StatusBase:
         return self._exception
 
     @tracer.start_as_current_span(f"{_TRACE_PREFIX} wait")
-    def wait(
-        self, timeout: float | None = None, timeout_exception: Exception | None = None
-    ):
+    def wait(self, timeout=None, timeout_exception=None):
         """
         Block until the action completes.
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -439,7 +439,9 @@ class StatusBase:
         return self._exception
 
     @tracer.start_as_current_span(f"{_TRACE_PREFIX} wait")
-    def wait(self, timeout=None):
+    def wait(
+        self, timeout: float | None = None, timeout_exception: Exception | None = None
+    ):
         """
         Block until the action completes.
 
@@ -450,6 +452,11 @@ class StatusBase:
         ----------
         timeout: Union[Number, None], optional
             If None (default) wait indefinitely until the status finishes.
+
+        timeout_exception: Exception, optional
+            If None (default), WaitTimeoutError will be raised if the status
+            does not complete within ``timeout``. If this is set to an Exception,
+            that exception will be raised instead.
 
         Raises
         ------
@@ -465,9 +472,14 @@ class StatusBase:
             indicates that the action itself raised ``TimeoutError``, distinct
             from ``WaitTimeoutError`` above.
         """
+        exception_to_raise = (
+            timeout_exception
+            if isinstance(timeout_exception, Exception)
+            else WaitTimeoutError(f"Status {self!r} has not completed yet.")
+        )
         _set_trace_attributes(trace.get_current_span(), self._trace_attributes)
         if not self._event.wait(timeout=timeout):
-            raise WaitTimeoutError(f"Status {self!r} has not completed yet.")
+            raise exception_to_raise
         if self._exception is not None:
             raise self._exception
 

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -437,6 +437,15 @@ def test_wait_timeout():
     with pytest.raises(WaitTimeoutError):
         st.exception(0.01)
 
+    custom_exception = ValueError("My custom exception")
+    with pytest.raises(ValueError) as exc:
+        st.wait(0.01, timeout_exception=custom_exception)
+        assert exc.value is custom_exception
+
+    # Wrong input should raise WaitTimeoutError
+    with pytest.raises(WaitTimeoutError):
+        st.wait(0.01, timeout_exception="Not an exception")
+
 
 def test_status_timeout():
     """


### PR DESCRIPTION
# Summary
This PR adds the option to specify a custom exception to the .wait() method. 

## Use Case
If you want to raise a specific Exception upon running into a Timeout during the `.wait(timeout=...)` method, a try/except statement is needed. This PR adds the option to in addition specify a 'timeout_exception' to the `.wait()` method of StatusBase. This allows the simpler syntax below, without try/except.

``` python
status = my_device.trigger()
status.wait(timeout=5, timeout_exception=TimeoutError(f"Device {self.name} timed out in trigger method.")
```