### PR TITLE
Add option to DeviceStatus to skip "stop" call on failure

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -694,7 +694,9 @@ class DeviceStatus(StatusBase):
     def __init__(self, device, call_stop_on_failure: bool = True, **kwargs):
         self.device = device
         self._watchers = []
-        self._call_stop_on_failure = call_stop_on_failure if isinstance(call_stop_on_failure, bool) else True
+        self._call_stop_on_failure = (
+            call_stop_on_failure if isinstance(call_stop_on_failure, bool) else True
+        )
         super().__init__(**kwargs)
         self._trace_attributes.update(
             {"device_name": device.name, "device_type": device.__class__.__name__}

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -691,9 +691,10 @@ class DeviceStatus(StatusBase):
         status has completed to running callbacks. Default is 0.
     """
 
-    def __init__(self, device, **kwargs):
+    def __init__(self, device, call_stop_on_failure: bool = True, **kwargs):
         self.device = device
         self._watchers = []
+        self._call_stop_on_failure = call_stop_on_failure if isinstance(call_stop_on_failure, bool) else True
         super().__init__(**kwargs)
         self._trace_attributes.update(
             {"device_name": device.name, "device_type": device.__class__.__name__}
@@ -705,7 +706,7 @@ class DeviceStatus(StatusBase):
     def _handle_failure(self):
         super()._handle_failure()
         self.log.debug("Trying to stop %s", repr(self.device))
-        if hasattr(self.device, "stop"):
+        if hasattr(self.device, "stop") and self._call_stop_on_failure:
             self.device.stop()
 
     def __str__(self):

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -681,6 +681,9 @@ class DeviceStatus(StatusBase):
 
     Parameters
     ----------
+    call_stop_on_failure: bool, optional
+        This option determines whether the device's ``stop()`` method is called
+        if the status fails. Default is True.
     timeout: float, optional
         The amount of time to wait before marking the Status as failed.  If
         ``None`` (default) wait forever. It is strongly encouraged to set a
@@ -691,12 +694,10 @@ class DeviceStatus(StatusBase):
         status has completed to running callbacks. Default is 0.
     """
 
-    def __init__(self, device, call_stop_on_failure: bool = True, **kwargs):
+    def __init__(self, device, *, call_stop_on_failure=True, **kwargs):
         self.device = device
         self._watchers = []
-        self._call_stop_on_failure = (
-            call_stop_on_failure if isinstance(call_stop_on_failure, bool) else True
-        )
+        self._call_stop_on_failure = bool(call_stop_on_failure)
         super().__init__(**kwargs)
         self._trace_attributes.update(
             {"device_name": device.name, "device_type": device.__class__.__name__}
@@ -708,7 +709,7 @@ class DeviceStatus(StatusBase):
     def _handle_failure(self):
         super()._handle_failure()
         self.log.debug("Trying to stop %s", repr(self.device))
-        if hasattr(self.device, "stop") and self._call_stop_on_failure:
+        if self._call_stop_on_failure and hasattr(self.device, "stop"):
             self.device.stop()
 
     def __str__(self):

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -1,5 +1,6 @@
 import time
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
+
 
 import pytest
 
@@ -11,6 +12,7 @@ from ophyd.status import (
     StatusBase,
     SubscriptionStatus,
     UseNewProperty,
+    DeviceStatus
 )
 from ophyd.utils import (
     InvalidState,
@@ -424,6 +426,20 @@ def test_exception_success_path():
     st.set_finished()
     assert st.wait(1) is None
     assert st.exception() is None
+
+def test_device_status_failure():
+    dev = Device(name="dev")
+    st = DeviceStatus(dev)
+    with patch.object(dev, "stop") as mock_stop:
+        st.set_exception(Exception("fail"))
+        assert mock_stop.call_count == 1
+    
+    st2 = DeviceStatus(dev, call_stop_on_failure=False)
+    with patch.object(dev, "stop") as mock_stop:
+        st2.set_exception(Exception("fail"))
+        assert mock_stop.call_count == 0
+
+
 
 
 def test_wait_timeout():

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -1,18 +1,17 @@
 import time
 from unittest.mock import MagicMock, Mock, patch
 
-
 import pytest
 
 from ophyd import Device
 from ophyd.signal import EpicsSignalRO
 from ophyd.status import (
+    DeviceStatus,
     MoveStatus,
     StableSubscriptionStatus,
     StatusBase,
     SubscriptionStatus,
     UseNewProperty,
-    DeviceStatus
 )
 from ophyd.utils import (
     InvalidState,
@@ -427,19 +426,17 @@ def test_exception_success_path():
     assert st.wait(1) is None
     assert st.exception() is None
 
+
 def test_device_status_failure():
     dev = Device(name="dev")
     st = DeviceStatus(dev)
     with patch.object(dev, "stop") as mock_stop:
         st.set_exception(Exception("fail"))
         assert mock_stop.call_count == 1
-    
     st2 = DeviceStatus(dev, call_stop_on_failure=False)
     with patch.object(dev, "stop") as mock_stop:
         st2.set_exception(Exception("fail"))
         assert mock_stop.call_count == 0
-
-
 
 
 def test_wait_timeout():


### PR DESCRIPTION
# Summary
This PR adds a kwarg to DeviceStatus that allows to specify whether 'stop' should be called on the device upon failure of the DeviceStatus.

## Use Case
A DeviceStatus is useful as it carries an instance of the device object itself. This is convenient to simplify access to signals and methods of the device in callback methods. However, it would be nice to be able to have fine-grained control of whether the DeviceStatus calls 'stop' on failure as there may be additional logic governing whether this is desired or not. This PR simply adds an optional kwarg to prohibit 'stop' from being called upon failure 