### PR TITLE
Add CompareStatus, TransitionStatus, AllAndStatus and OrAnyStatus

### DIFF
--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -5,7 +5,6 @@ import pytest
 
 from ophyd import Device
 from ophyd.signal import EpicsSignalRO, Signal
-from ophyd.sim import FakeEpicsSignalRO
 from ophyd.status import (
     DeviceStatus,
     MoveStatus,
@@ -611,6 +610,7 @@ def test_error_in_handle_failure_method():
     time.sleep(0.1)  # Wait for callbacks to run.
     assert state
 
+
 def test_compare_status_number():
     """Test CompareStatus with different operations."""
     sig = Signal(name="test_signal", value=0)
@@ -689,9 +689,11 @@ def test_transition_status():
     assert status.success is True
     assert status.exception() is None
 
-    # Test strict=True, ra
+    # Test strict=True, raise_states
     sig.put(1)
-    status = TransitionStatus(signal=sig, transitions=[1, 2, 3], strict=True, raise_states=[4])
+    status = TransitionStatus(
+        signal=sig, transitions=[1, 2, 3], strict=True, raise_states=[4]
+    )
     assert status.done is False
     sig.put(4)
     with pytest.raises(ValueError):
@@ -770,8 +772,9 @@ def test_transition_status_strings():
     assert status.done is True
     assert status.success is True
 
+
 def test_and_all_status():
-    """ Test AndAllStatus """
+    """Test AndAllStatus"""
     dev = Device("Tst:Prefix", name="test")
     st1 = StatusBase()
     st2 = StatusBase()
@@ -802,12 +805,16 @@ def test_and_all_status():
     assert and_status.success is False
     assert st2.success is False
     assert st3.success is False
-    assert st3.done is False # Not resolved before failure
-    assert st1.success is True # Already resolved before failure
-    # Exception is propagated to all unresolved statuses
+
+    # Not resolved before failure
+    assert st3.done is False
+
+    # Already resolved before failure
+    assert st1.success is True
+
 
 def test_or_any_status():
-    """ Test OrAnyStatus """
+    """Test OrAnyStatus"""
     dev = Device("Tst:Prefix", name="test")
     st1 = StatusBase()
     st2 = StatusBase()
@@ -834,7 +841,7 @@ def test_or_any_status():
     assert or_status.done is True
     assert or_status.success is False
     assert isinstance(or_status.exception(), RuntimeError)
-    assert str(or_status.exception()) == "Exception: Test exception; RuntimeError: Test exception 2; ValueError: Test exception 3"
-
-
-
+    assert (
+        str(or_status.exception())
+        == "Exception: Test exception; RuntimeError: Test exception 2; ValueError: Test exception 3"
+    )


### PR DESCRIPTION
# Summary
This PR adds 4 new StatusObjects that simplify signal comparison, transitions or combining status objects.

## CompareStatus
Status to compare updates from a signal. It supports float & int for a few operations ('==', '!=', '<', '<=', '>', '>='.) and strings for '==', '!='. A list of values can be specified for which an exception should be set on the status.

```python
from ophyd.signal import Signal
from ophyd.status import CompareStatus
sig = Signal(name='sig')
sig.put(0)
status = CompareStatus(signal=sig, value=5, operation=">")
sig.put(1)
status.done # is true
```

## TransitionStatus
Status to define a transition of states that the signal needs to run through. It is possible to specify whether the transition should be strict. A list of values can be specified for which an exception should be set.

```python
from ophyd.signal import Signal
from ophyd.status import TransitionStatus
sig = Signal(name='sig')
sig.put(0)
status = TransitionStatus(signal=sig, transitions=[1, 2, 3], strict=False)
sig.put(0)
sig.put(0)
sig.put(0)
status.done # is true
```

## AndAllStatus
Similar to AndStatus, but a DeviceStatus and takes a list of status objects. 

``` python
from ophyd import Device
from ophyd.status import AndAllStatus, StatusBase, DeviceStatus

dev = Device(name='dev')
st1 = StatusBase()
st2 = DeviceStatus()

and_st = AndAllStatus(dev, [st1,st2])
st1.set_finished()
st2.set_finished()
and_st.done # is True
```

## OrAnyStatus
Similar to OrStatus, but a DeviceStatus and takes a list of status objects. 

``` python
from ophyd import Device
from ophyd.status import OrAnyStatus, StatusBase, DeviceStatus

dev = Device(name='dev')
st1 = StatusBase()
st2 = DeviceStatus(dev)

and_st = OrAnyStatus(dev, [st1,st2])
st1.set_finished()
and_st.done # is True
```